### PR TITLE
Convert uuid type to CHAR(36)

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -7,6 +7,9 @@ require 'byebug'
 def normalize_types(type)
   if %w(hstore json jsonb text).include?(type)
     'CHARACTER VARYING(max)'
+  elsif %w(uuid).include?(type)
+    # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003
+    'CHAR(36)'
   else
     type
   end


### PR DESCRIPTION
Convert the `uuid` type to `CHAR(36)` as described at https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003