### PR TITLE
Use "CHARACTER VARYING(max)" for any instance of "character varying"

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -5,7 +5,7 @@ require 'json'
 require 'byebug'
 
 def normalize_types(type)
-  if (['hstore', 'json', 'jsonb', 'text', 'character varying']).include?(type)
+  if (['hstore', 'json', 'jsonb', 'text']).include?(type) || type.include?('character varying')
     'CHARACTER VARYING(max)'
   elsif %w(uuid).include?(type)
     # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003


### PR DESCRIPTION
Use "CHARACTER VARYING(max)" for any instance of "character varying", even if a length is set. Redshift treats the limit as bytes, unlike Postgres which treats it as characters, so using the same length value in Redshift can result in an import error if the field contains multi-byte characters.