### PR TITLE
Handle custom values for sql_types that are actually enums

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -4,16 +4,15 @@ require 'net/http'
 require 'json'
 require 'byebug'
 
-def normalize_types(type)
-  if (['hstore', 'json', 'jsonb', 'text']).include?(type) || type.include?('character varying')
+def normalize_types(type, sql_type)
+  if (['enum']).include?(type) || (['hstore', 'json', 'jsonb', 'text']).include?(sql_type) || sql_type.include?('character varying')
     'CHARACTER VARYING(max)'
-  elsif %w(uuid).include?(type)
+  elsif %w(uuid).include?(sql_type)
     # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003
     'CHAR(36)'
   else
-    type
+    sql_type
   end
-
 end
 
 
@@ -24,7 +23,7 @@ tables = JSON.parse(json)['tables']
 tables.each do |table|
   name = table['table']['name']
   columns = table['table']['columns']
-  column_fields = columns.collect{|col, attrs| "\"#{col}\" #{normalize_types(attrs["sql_type"])}" }.join(', ')
+  column_fields = columns.collect{|col, attrs| "\"#{col}\" #{normalize_types(attrs["type"], attrs["sql_type"])}" }.join(', ')
   puts "DROP TABLE IF EXISTS #{name};"
   puts "CREATE TABLE #{name} (#{column_fields});"
 end


### PR DESCRIPTION
An `enum` column comes through as a custom `sql_type` which doesn't map to anything. So check if `type` is `enum` and map it to `CHARACTER VARYING(max)`.