### PR TITLE
Normalize timestamp columns in generated DDL

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -13,7 +13,7 @@ def normalize_types(type, sql_type)
   elsif %w(datetime).include?(type)
     # Redshift timestamp column does not support precision, but some of our newer timestamp columns include it,
     # so normalize on the non-precision version
-    'timestamp without time zone'
+    'TIMESTAMP WITHOUT TIME ZONE'
   else
     sql_type
   end

--- a/create_tables.rb
+++ b/create_tables.rb
@@ -10,6 +10,10 @@ def normalize_types(type, sql_type)
   elsif %w(uuid).include?(sql_type)
     # https://gist.github.com/wrobstory/4b0ce4e8ba51ec40c494881bc126c003
     'CHAR(36)'
+  elsif %w(datetime).include?(type)
+    # Redshift timestamp column does not support precision, but some of our newer timestamp columns include it,
+    # so normalize on the non-precision version
+    'timestamp without time zone'
   else
     sql_type
   end


### PR DESCRIPTION
This updates the `create_tables.rb` script, which consumes [our bulk data schema endpoint](https://demo.controlshiftlabs.com/api/bulk_data/schema.json) and generates DDL for initializing a Redshift schema.

For most of the tables loaded by this script, the timestamp columns have type `timestamp without time zone`. But for a few of our tables that recently had timestamps added, the column type is `timestamp(6) without time zone`. Redshift can't handle that syntax (it throw an `ERROR: timestamp column does not support precision.`), so we need to normalize on a timestamp type without precision.

This fixes the issue that prevented the `campaign_admins`, `daisy_chain_rules`, and `petition_starts` tables from being created in Redshift.