### PR TITLE
Convert geography column type for compatibility with Redshift

### DIFF
--- a/create_tables.rb
+++ b/create_tables.rb
@@ -15,6 +15,8 @@ def normalize_types(type, sql_type)
     # so normalize on the non-precision version
     'TIMESTAMP WITHOUT TIME ZONE'
   elsif type.include?('geography')
+    # Normalize column type definitions like "geography(Point,4326)" to be compatible with Redshift, which
+    # expects the type to just be "GEOGRAPHY"
     'GEOGRAPHY'
   else
     sql_type

--- a/create_tables.rb
+++ b/create_tables.rb
@@ -14,6 +14,8 @@ def normalize_types(type, sql_type)
     # Redshift timestamp column does not support precision, but some of our newer timestamp columns include it,
     # so normalize on the non-precision version
     'TIMESTAMP WITHOUT TIME ZONE'
+  elsif type.include?('geography')
+    'GEOGRAPHY'
   else
     sql_type
   end


### PR DESCRIPTION
The `locations` table has a column that is of type `geography(Point,4326)`, but this is not valid for Redshift. This PR converts this to `GEOGRAPHY`.